### PR TITLE
Capture NetSuite identifiers and surface them in popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -42,6 +42,13 @@
   </div>
 
   <div class="section">
+    <div class="title">NetSuite</div>
+    <div id="netsuite">
+      <div class="muted">Sin datos detectados.</div>
+    </div>
+  </div>
+
+  <div class="section">
     <div class="title">Resultado</div>
     <div id="result">
       <div class="muted">Sin resultados aún.</div>


### PR DESCRIPTION
## Summary
- detect NetSuite internal and BigCommerce IDs alongside SKU in the content script and send richer updates
- persist the last detected NetSuite payload per tab in the background worker so the popup can request it
- refresh the popup to fetch the stored payload, populate the SKU automatically, and display a NetSuite card with copy actions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd6ce5da308325be10983bad869122