### PR TITLE
Redesign popup cards and comparison states

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -4,36 +4,68 @@
   <meta charset="utf-8">
   <title>BC SKU Lookup</title>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 12px; width: 340px; }
-    .section { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; padding: 10px; margin-bottom: 10px; }
-    .title { font-weight: 700; font-size: 16px; margin: 0 0 8px 0; display: flex; align-items: center; gap: 8px; }
-    .muted { color: #6b7280; font-size: 12px; }
-    .row { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; }
-    input { width: 100%; padding: 8px; font-size: 14px; border-radius: 8px; border: 1px solid #d1d5db; box-sizing: border-box; }
-    .btn { padding: 8px 10px; border-radius: 8px; border: none; font-weight: 600; cursor: pointer; }
+    * { box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; padding: 12px; width: 360px; background: #f8fafc; color: #0f172a; }
+    .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 16px; padding: 14px; margin-bottom: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+    .card-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 12px; }
+    .card-title { font-weight: 700; font-size: 16px; color: #111827; }
+    .card-subtitle { font-size: 12px; margin-top: 2px; }
+    .muted { color: #6b7280; }
+    .control-grid { display: grid; grid-template-columns: 1fr auto; gap: 8px; }
+    .action-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-top: 8px; }
+    input { width: 100%; padding: 8px 10px; font-size: 14px; border-radius: 10px; border: 1px solid #d1d5db; background: #fff; color: #111827; }
+    .btn { padding: 8px 10px; border-radius: 10px; border: none; font-weight: 600; cursor: pointer; font-size: 13px; transition: background 0.2s, border-color 0.2s; }
     .btn.primary { background: #4f46e5; color: #fff; }
+    .btn.primary:hover { background: #4338ca; }
     .btn.secondary { background: #f3f4f6; color: #111827; border: 1px solid #e5e7eb; }
-    .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
-    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-    .kv { display: grid; grid-template-columns: 105px 1fr auto; gap: 6px; align-items: center; padding: 6px; border: 1px solid #eef2ff; background: #f8fafc; border-radius: 10px; }
-    .kv label { font-size: 12px; color: #475569; font-weight: 600; }
-    .kv code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 2px 6px; border-radius: 6px; background: #fff; border: 1px solid #e5e7eb; word-break: break-all; }
-    .copy { font-size: 12px; }
-    .status { font-size: 12px; margin-top: 6px; }
-    .status.ok { color: #059669; }
+    .btn.secondary:hover { background: #e5e7eb; }
+    .btn.ghost { background: #f9fafb; color: #1f2937; border: 1px solid #e5e7eb; }
+    .btn.ghost:hover { background: #eef2ff; }
+    .status { font-size: 12px; margin-top: 8px; min-height: 16px; }
+    .status.ok { color: #047857; }
     .status.bad { color: #dc2626; }
-    .toast { position: fixed; bottom: 8px; left: 50%; transform: translateX(-50%); background: #111827; color: #fff; padding: 6px 10px; border-radius: 999px; font-size: 12px; opacity: 0; transition: opacity .2s; }
+    .hidden { display: none !important; }
+    #netsuiteBody, #bcDetails { display: flex; flex-direction: column; gap: 8px; }
+    .placeholder { padding: 14px; border-radius: 12px; background: #f1f5f9; border: 1px dashed #cbd5f5; font-size: 12px; text-align: center; }
+    .id-row { display: grid; grid-template-columns: auto 1fr auto; gap: 8px; align-items: center; padding: 8px 10px; border: 1px solid #e5e7eb; border-radius: 12px; background: #f9fafb; }
+    .id-label { font-size: 11px; font-weight: 700; color: #475569; text-transform: uppercase; letter-spacing: 0.05em; }
+    .id-value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 4px 6px; border-radius: 6px; background: #ffffff; border: 1px solid #e5e7eb; min-height: 20px; display: flex; align-items: center; word-break: break-all; }
+    .comparison-section { margin-top: 4px; display: flex; flex-direction: column; gap: 10px; }
+    .comparison-list { display: flex; flex-direction: column; gap: 8px; }
+    .compare-row { border: 1px solid #e5e7eb; border-radius: 12px; padding: 10px 12px; transition: box-shadow 0.2s ease; }
+    .compare-top { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+    .compare-label { font-weight: 600; font-size: 13px; color: #1f2937; }
+    .state-chip { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.06em; }
+    .compare-values { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin-top: 8px; }
+    .source-value { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: #475569; }
+    .source-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: #64748b; }
+    .source-value code { display: block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 4px 6px; border-radius: 6px; border: 1px solid rgba(148, 163, 184, 0.6); background: rgba(248, 250, 252, 0.8); color: #0f172a; word-break: break-all; }
+    .state-match { background: #f0fdf4; border-color: #bbf7d0; }
+    .state-match .state-chip { background: #bbf7d0; color: #166534; }
+    .state-missing { background: #fffbeb; border-color: #fde68a; }
+    .state-missing .state-chip { background: #fde68a; color: #92400e; }
+    .state-mismatch { background: #fef2f2; border-color: #fca5a5; }
+    .state-mismatch .state-chip { background: #fca5a5; color: #b91c1c; }
+    .banner { font-size: 12px; font-weight: 600; padding: 8px 10px; border-radius: 12px; border: 1px solid transparent; }
+    .banner.is-warning { background: #fef3c7; border-color: #fde68a; color: #b45309; }
+    .banner.is-error { background: #fee2e2; border-color: #fecaca; color: #b91c1c; }
+    .toast { position: fixed; bottom: 12px; left: 50%; transform: translateX(-50%); background: #111827; color: #fff; padding: 6px 12px; border-radius: 999px; font-size: 12px; opacity: 0; transition: opacity .2s ease; box-shadow: 0 6px 18px rgba(15, 23, 42, 0.3); }
     .toast.show { opacity: 1; }
   </style>
 </head>
 <body>
-  <div class="section">
-    <div class="title">BigCommerce SKU Lookup</div>
-    <div class="row" style="grid-template-columns: 1fr auto;">
+  <div class="card control-card">
+    <div class="card-header">
+      <div>
+        <div class="card-title">BigCommerce SKU Lookup</div>
+        <div class="card-subtitle muted">Buscá IDs y comparalos con NetSuite.</div>
+      </div>
+    </div>
+    <div class="control-grid">
       <input id="sku" placeholder="SKU..." />
       <button class="btn secondary" id="useDetected">Usar detectada</button>
     </div>
-    <div class="grid-3" style="margin-top:8px;">
+    <div class="action-grid">
       <button class="btn primary" id="lookup">Buscar</button>
       <button class="btn secondary" id="openOptions">Options</button>
       <button class="btn secondary" id="unlockBtn">Unlock</button>
@@ -41,17 +73,31 @@
     <div id="status" class="status muted"></div>
   </div>
 
-  <div class="section">
-    <div class="title">NetSuite</div>
-    <div id="netsuite">
-      <div class="muted">Sin datos detectados.</div>
+  <div class="card" id="netsuiteCard">
+    <div class="card-header" id="netsuiteHeader">
+      <div>
+        <div class="card-title">NetSuite IDs</div>
+        <div class="card-subtitle muted" id="netsuiteMeta">Esperando datos detectados.</div>
+      </div>
+    </div>
+    <div class="card-body" id="netsuiteBody">
+      <div class="placeholder muted">Sin datos detectados.</div>
     </div>
   </div>
 
-  <div class="section">
-    <div class="title">Resultado</div>
-    <div id="result">
-      <div class="muted">Sin resultados aún.</div>
+  <div class="card hidden" id="bigcommerceCard">
+    <div class="card-header" id="bcHeader">
+      <div>
+        <div class="card-title">BigCommerce IDs</div>
+        <div class="card-subtitle muted" id="bcMeta">Consultá un SKU para ver IDs.</div>
+      </div>
+    </div>
+    <div class="card-body">
+      <div id="bcDetails"></div>
+      <div class="comparison-section hidden" id="comparisonSection">
+        <div id="comparisonBanner" class="banner hidden"></div>
+        <div id="comparisonResults" class="comparison-list"></div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- redesign the popup with dedicated NetSuite and BigCommerce cards, copy controls, and refreshed styling
- render NetSuite detections immediately and show BigCommerce lookups with comparison rows once a search succeeds
- add comparison logic with match/missing/mismatch states, tooltips, and conditional banners for discrepancies

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd7813af608325a6ecc3ef59bc632c