### PR TITLE
Localize extension UI to English

### DIFF
--- a/background.js
+++ b/background.js
@@ -38,7 +38,7 @@ function authHeaders(cfg) {
 
 async function bcLookup(sku) {
   const cfg = await getSettingsUnlocked();
-  if (!cfg.storeHash || !cfg.accessToken) throw new Error("Config incompleta. Desbloqueá en Options.");
+  if (!cfg.storeHash || !cfg.accessToken) throw new Error("Incomplete configuration. Unlock in Options.");
   const base = `https://api.bigcommerce.com/stores/${cfg.storeHash}/v3`;
 
   // 1) variants?sku=
@@ -64,11 +64,11 @@ async function bcLookup(sku) {
     }
   }
 
-  throw new Error(`SKU "${sku}" no encontrado en BigCommerce.`);
+  throw new Error(`SKU "${sku}" not found in BigCommerce.`);
 }
 
 chrome.runtime.onInstalled.addListener(() => {
-  chrome.contextMenus.create({ id: "bc-lookup-selection", title: "Buscar en BigCommerce: \"%s\"", contexts: ["selection"] });
+  chrome.contextMenus.create({ id: "bc-lookup-selection", title: "Search in BigCommerce: \"%s\"", contexts: ["selection"] });
 });
 
 chrome.tabs.onRemoved.addListener((tabId) => {
@@ -117,7 +117,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         // msg.bundle (encrypted), msg.passphrase
         const { bc_encrypted } = await getEncrypted();
         const bundle = msg.bundle || bc_encrypted;
-        if (!bundle) throw new Error("No hay credenciales guardadas.");
+        if (!bundle) throw new Error("No credentials saved.");
         const creds = await decryptJSON(bundle, msg.passphrase);
         await setUnlocked(creds);
         sendResponse({ ok: true });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "BigCommerce SKU Lookup for NetSuite",
-  "description": "Detecta SKU (itemid) en NetSuite y busca Product/Variant ID en BigCommerce. Soporte de credenciales cifradas.",
+  "description": "Detects SKUs (itemid) in NetSuite and fetches BigCommerce Product/Variant IDs. Supports encrypted credentials.",
   "version": "1.2.0",
   "icons": {
     "16": "icons/icon16.png",

--- a/options-secure.js
+++ b/options-secure.js
@@ -9,25 +9,25 @@ async function saveEncrypted(){
     accessToken: $('accessToken').value.trim(),
     clientId: $('clientId').value.trim(),
   };
-  if (!pass) { alert('Definí una contraseña'); return; }
-  if (!obj.storeHash || !obj.accessToken) { alert('Store Hash y Access Token son obligatorios'); return; }
+  if (!pass) { alert('Set a password'); return; }
+  if (!obj.storeHash || !obj.accessToken) { alert('Store Hash and Access Token are required'); return; }
   const bundle = await encryptJSON(obj, pass);
   await new Promise(res => chrome.storage.local.set({ bc_encrypted: bundle }, res));
-  alert('Guardado cifrado.');
+  alert('Encrypted data saved.');
 }
 
 $('save').addEventListener('click', saveEncrypted);
 
 $('unlock').addEventListener('click', async () => {
   const pass = $('passphrase').value;
-  if (!pass) { alert('Ingresá tu contraseña'); return; }
+  if (!pass) { alert('Enter your password'); return; }
   const res = await chrome.runtime.sendMessage({ type: "unlock-creds", passphrase: pass });
-  $('out').textContent = res?.ok ? 'Desbloqueado ✅' : (res?.error || 'Error');
+  $('out').textContent = res?.ok ? 'Unlocked ✅' : (res?.error || 'Error');
 });
 
 $('lock').addEventListener('click', async () => {
   const res = await chrome.runtime.sendMessage({ type: "lock-creds" });
-  $('out').textContent = res?.ok ? 'Bloqueado 🔒' : (res?.error || 'Error');
+  $('out').textContent = res?.ok ? 'Locked 🔒' : (res?.error || 'Error');
 });
 
 $('testBtn').addEventListener('click', async () => {

--- a/options.html
+++ b/options.html
@@ -16,35 +16,35 @@
 </head>
 <body>
   <h2>BigCommerce SKU Lookup • Options (Secure)</h2>
-  <p class="muted">Tus credenciales se guardan cifradas con una <b>contraseña</b> que definís acá. La extensión solo las descifra en memoria por 15 minutos de inactividad.</p>
+  <p class="muted">Your credentials are stored encrypted with a <b>password</b> you define here. The extension only decrypts them in memory for 15 minutes of inactivity.</p>
 
-  <div class="warn">Importante: esto mejora la privacidad, pero no reemplaza un backend. En un navegador, un usuario avanzado aún puede inspeccionar red/memoria.</div>
+  <div class="warn">Important: this improves privacy but does not replace a backend. In a browser, an advanced user can still inspect network traffic or memory.</div>
 
-  <label>Contraseña (para cifrar/descifrar)</label>
-  <input id="passphrase" placeholder="Definí una contraseña" type="password" />
+  <label>Password (for encryption/decryption)</label>
+  <input id="passphrase" placeholder="Set a password" type="password" />
 
   <label>Store Hash</label>
-  <input id="storeHash" placeholder="ej: abcdefg" />
+  <input id="storeHash" placeholder="e.g. abcdefg" />
 
   <label>Access Token</label>
   <input id="accessToken" placeholder="Access Token" />
 
-  <label>Client ID (opcional)</label>
-  <input id="clientId" placeholder="Client ID (si tu setup lo requiere)" />
+  <label>Client ID (optional)</label>
+  <input id="clientId" placeholder="Client ID (if your setup needs it)" />
 
-  <button id="save">Guardar cifrado</button>
+  <button id="save">Save encrypted</button>
 
-  <h3>Probar lookup</h3>
+  <h3>Test lookup</h3>
   <div class="row">
     <div>
-      <label>SKU de prueba</label>
-      <input id="testSku" placeholder="Ingresá un SKU" />
-      <button id="unlock">Desbloquear</button>
-      <button id="testBtn">Probar Lookup</button>
-      <button id="lock">Bloquear</button>
+      <label>Test SKU</label>
+      <input id="testSku" placeholder="Enter an SKU" />
+      <button id="unlock">Unlock</button>
+      <button id="testBtn">Run lookup</button>
+      <button id="lock">Lock</button>
     </div>
     <div>
-      <label>Resultado</label>
+      <label>Result</label>
       <pre id="out"></pre>
     </div>
   </div>

--- a/popup.html
+++ b/popup.html
@@ -58,15 +58,15 @@
     <div class="card-header">
       <div>
         <div class="card-title">BigCommerce SKU Lookup</div>
-        <div class="card-subtitle muted">Buscá IDs y comparalos con NetSuite.</div>
+        <div class="card-subtitle muted">Look up IDs and compare them with NetSuite.</div>
       </div>
     </div>
     <div class="control-grid">
       <input id="sku" placeholder="SKU..." />
-      <button class="btn secondary" id="useDetected">Usar detectada</button>
+      <button class="btn secondary" id="useDetected">Use detected</button>
     </div>
     <div class="action-grid">
-      <button class="btn primary" id="lookup">Buscar</button>
+      <button class="btn primary" id="lookup">Look up</button>
       <button class="btn secondary" id="openOptions">Options</button>
       <button class="btn secondary" id="unlockBtn">Unlock</button>
     </div>
@@ -77,11 +77,11 @@
     <div class="card-header" id="netsuiteHeader">
       <div>
         <div class="card-title">NetSuite IDs</div>
-        <div class="card-subtitle muted" id="netsuiteMeta">Esperando datos detectados.</div>
+        <div class="card-subtitle muted" id="netsuiteMeta">Waiting for detected data.</div>
       </div>
     </div>
     <div class="card-body" id="netsuiteBody">
-      <div class="placeholder muted">Sin datos detectados.</div>
+      <div class="placeholder muted">No detected data.</div>
     </div>
   </div>
 
@@ -89,7 +89,7 @@
     <div class="card-header" id="bcHeader">
       <div>
         <div class="card-title">BigCommerce IDs</div>
-        <div class="card-subtitle muted" id="bcMeta">Consultá un SKU para ver IDs.</div>
+        <div class="card-subtitle muted" id="bcMeta">Look up an SKU to view IDs.</div>
       </div>
     </div>
     <div class="card-body">
@@ -101,7 +101,7 @@
     </div>
   </div>
 
-  <div id="toast" class="toast">Copiado</div>
+  <div id="toast" class="toast">Copied</div>
 
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -16,7 +16,7 @@ function setStatus(msg, ok=null){
 
 function toast(msg){
   const t = $('toast');
-  t.textContent = msg || 'Copiado';
+  t.textContent = msg || 'Copied';
   t.classList.add('show');
   setTimeout(()=>t.classList.remove('show'), 900);
 }
@@ -30,9 +30,9 @@ function attachCopyHandlers(root){
       if (text) {
         try {
           await navigator.clipboard.writeText(text);
-          toast('Copiado');
+          toast('Copied');
         } catch (e) {
-          toast('No se pudo copiar');
+          toast('Could not copy');
         }
       }
     });
@@ -66,7 +66,7 @@ function renderIdRow(label, id, value) {
     <div class="id-row">
       <div class="id-label">${escapeHtml(label)}</div>
       <code class="id-value" id="${id}">${display}</code>
-      <button class="btn ghost copy" data-copy="#${id}">Copiar</button>
+      <button class="btn ghost copy" data-copy="#${id}">Copy</button>
     </div>
   `;
 }
@@ -102,8 +102,8 @@ function updateComparisonSection(){
 
   const netsuite = latestNetSuitePayload || {};
   const bc = lastSearchResult || {};
-  const detectionLabel = netsuite?.detectedAt ? formatTimestamp(netsuite.detectedAt) : 'sin registro';
-  const sourceLabel = bc?.source ? bc.source : 'Desconocida';
+  const detectionLabel = netsuite?.detectedAt ? formatTimestamp(netsuite.detectedAt) : 'no record';
+  const sourceLabel = bc?.source ? bc.source : 'Unknown';
   const fetchedLabel = bc?.fetchedAt ? formatTimestamp(bc.fetchedAt) : null;
   const bcInfo = fetchedLabel ? `${sourceLabel} · ${fetchedLabel}` : sourceLabel;
 
@@ -124,13 +124,13 @@ function updateComparisonSection(){
       const missingSides = [];
       if (!nsHas) missingSides.push('NetSuite');
       if (!bcHas) missingSides.push('BigCommerce');
-      issues.push({ type: 'missing', message: `${label}: falta dato en ${missingSides.join(' y ')}` });
+      issues.push({ type: 'missing', message: `${label}: missing data in ${missingSides.join(' and ')}` });
     } else if (nsNormalized !== bcNormalized) {
       state = 'mismatch';
-      issues.push({ type: 'mismatch', message: `${label}: los IDs no coinciden` });
+      issues.push({ type: 'mismatch', message: `${label}: IDs do not match` });
     }
-    const stateLabel = state === 'match' ? 'Coincide' : state === 'missing' ? 'Falta dato' : 'No coincide';
-    const tooltip = `NetSuite (${detectionLabel}): ${nsHas ? nsNormalized : 'sin dato'}\nBigCommerce (${bcInfo}): ${bcHas ? bcNormalized : 'sin dato'}`;
+    const stateLabel = state === 'match' ? 'Match' : state === 'missing' ? 'Missing data' : 'Mismatch';
+    const tooltip = `NetSuite (${detectionLabel}): ${nsHas ? nsNormalized : 'no data'}\nBigCommerce (${bcInfo}): ${bcHas ? bcNormalized : 'no data'}`;
     return `
       <div class="compare-row state-${state}" title="${escapeHtml(tooltip)}">
         <div class="compare-top">
@@ -164,7 +164,7 @@ function renderBCCard(data){
 
   if (!data) {
     lastSearchResult = null;
-    if (meta) meta.textContent = 'Consultá un SKU para ver IDs.';
+    if (meta) meta.textContent = 'Look up an SKU to view IDs.';
     if (header) header.removeAttribute('title');
     details.innerHTML = '';
     card.classList.add('hidden');
@@ -177,11 +177,11 @@ function renderBCCard(data){
 
   card.classList.remove('hidden');
 
-  const sourceText = normalized.source ? `Fuente: ${normalized.source}` : 'Fuente desconocida';
+  const sourceText = normalized.source ? `Source: ${normalized.source}` : 'Unknown source';
   if (meta) meta.textContent = sourceText;
   if (header) {
-    const headerSource = normalized.source ? `Fuente: ${normalized.source}` : 'Fuente desconocida';
-    header.title = `${headerSource} · Consultado ${formatTimestamp(normalized.fetchedAt)}`;
+    const headerSource = normalized.source ? `Source: ${normalized.source}` : 'Unknown source';
+    header.title = `${headerSource} · Retrieved ${formatTimestamp(normalized.fetchedAt)}`;
   }
 
   details.innerHTML = [
@@ -210,7 +210,7 @@ function renderNetSuite(payload){
   const hasAny = payload && (payload.sku || payload.internalId || payload.bcProductId || payload.bcVariantId);
 
   if (!hasAny) {
-    root.innerHTML = '<div class="placeholder muted">Sin datos detectados.</div>';
+    root.innerHTML = '<div class="placeholder muted">No detected data.</div>';
   } else {
     const { sku=null, internalId=null, bcProductId=null, bcVariantId=null } = payload;
     root.innerHTML = [
@@ -224,18 +224,18 @@ function renderNetSuite(payload){
 
   if (meta) {
     if (payload?.detectedAt) {
-      meta.textContent = `Detectado: ${formatTimestamp(payload.detectedAt)}`;
+      meta.textContent = `Detected: ${formatTimestamp(payload.detectedAt)}`;
     } else if (hasAny) {
-      meta.textContent = 'Detectado recientemente.';
+      meta.textContent = 'Detected recently.';
     } else {
-      meta.textContent = 'Esperando datos detectados.';
+      meta.textContent = 'Waiting for detected data.';
     }
   }
 
   if (header) {
     header.title = payload?.detectedAt
-      ? `Detectado en NetSuite el ${formatTimestamp(payload.detectedAt)}`
-      : 'Sin registro de detección.';
+      ? `Detected in NetSuite on ${formatTimestamp(payload.detectedAt)}`
+      : 'No detection record.';
   }
 
   updateComparisonSection();
@@ -284,9 +284,9 @@ async function applyDetectedFromPage(context='load'){
   if (!tab) {
     renderNetSuite(null);
     if (context === 'use') {
-      setStatus('No hay pestaña activa.', false);
+      setStatus('No active tab.', false);
     } else {
-      setStatus('No se detectó SKU. Podés ingresarla manualmente.', null);
+      setStatus('No SKU detected. You can enter it manually.', null);
     }
     return null;
   }
@@ -299,35 +299,35 @@ async function applyDetectedFromPage(context='load'){
     const hasAny = payload && (payload.sku || payload.internalId || payload.bcProductId || payload.bcVariantId);
     if (context === 'load') {
       if (payload?.sku) {
-        setStatus('SKU detectada automáticamente.', true);
+        setStatus('SKU detected automatically.', true);
       } else if (hasAny) {
-        setStatus('Datos de NetSuite detectados automáticamente.', true);
+        setStatus('NetSuite data detected automatically.', true);
       } else {
-        setStatus('No se detectó SKU. Podés ingresarla manualmente.', null);
+        setStatus('No SKU detected. You can enter it manually.', null);
       }
     } else if (context === 'use') {
       if (payload?.sku) {
-        setStatus('SKU detectada y aplicada.', true);
+        setStatus('Detected SKU applied.', true);
       } else if (hasAny) {
-        setStatus('Se detectaron datos de NetSuite, pero sin SKU.', true);
+        setStatus('Detected NetSuite data, but no SKU.', true);
       } else {
-        setStatus('No se detectó SKU en esta página.', false);
+        setStatus('No SKU detected on this page.', false);
       }
     }
     return payload;
   } catch (e) {
     renderNetSuite(null);
-    setStatus('No se pudo leer la página actual (¿es NetSuite?).', false);
+    setStatus('Could not read the current page (is it NetSuite?).', false);
     return null;
   }
 }
 
 // Unlock flow
 $('unlockBtn').addEventListener('click', async () => {
-  const pass = prompt('Ingresá tu contraseña para desbloquear credenciales:');
+  const pass = prompt('Enter your password to unlock credentials:');
   if (!pass) return;
   const res = await chrome.runtime.sendMessage({ type: "unlock-creds", passphrase: pass });
-  setStatus(res?.ok ? 'Credenciales desbloqueadas ✅' : (res?.error || 'Error'), !!res?.ok);
+  setStatus(res?.ok ? 'Credentials unlocked ✅' : (res?.error || 'Error'), !!res?.ok);
 });
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -341,8 +341,8 @@ $('useDetected').addEventListener('click', () => {
 
 $('lookup').addEventListener('click', async () => {
   const sku = $('sku').value.trim();
-  if (!sku) { setStatus('Ingresá un SKU.', false); return; }
-  setStatus('Consultando...');
+  if (!sku) { setStatus('Enter an SKU.', false); return; }
+  setStatus('Looking up...');
   const res = await chrome.runtime.sendMessage({ type: "bc-lookup", sku });
   if (res?.ok) {
     renderBCCard(res.data);
@@ -351,7 +351,7 @@ $('lookup').addEventListener('click', async () => {
     renderBCCard(null);
     setStatus(res?.error || 'Error', false);
     if (/LOCKED/.test(res?.error||'')) {
-      setStatus('Bloqueado 🔒 — usá "Unlock" o Options para desbloquear.', false);
+      setStatus('Locked 🔒 — use "Unlock" or Options to unlock.', false);
     }
   }
 });


### PR DESCRIPTION
## Summary
- translate the popup UI strings and runtime status/toast messaging to English
- update background lookup errors and the context menu title to English wording
- localize the secure options page text and align the manifest description with the new copy

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdba787ffc8325948887f3df667c43