### PR TITLE
Update badge handling for detection and lock status

### DIFF
--- a/content.js
+++ b/content.js
@@ -39,10 +39,21 @@ function getFallbackCandidates() {
 }
 function looksLikeSKU(s){ return /^[A-Za-z0-9_\-\.\/]+$/.test(s) && s.length>=2 && s.length<=120; }
 function pickSKU(c){ const f=c.filter(looksLikeSKU); if(!f.length) return null; const sep=f.filter(s=>/[-_\.]/.test(s)); return sep[0]||f[0]; }
-function findSKU(){
-  const a=getItemIdCandidates(); const fromItemId=pickSKU(a); if(fromItemId) return fromItemId;
-  const b=getFallbackCandidates(); const fromFallback=pickSKU(b); if(fromFallback) return fromFallback;
-  return null;
+function collectSkuDetection(){
+  const itemIdCandidates=getItemIdCandidates();
+  const fallbackCandidates=getFallbackCandidates();
+  const sku=pickSKU(itemIdCandidates)||pickSKU(fallbackCandidates)||null;
+  const seen=new Set();
+  const ordered=[];
+  for(const val of [...itemIdCandidates,...fallbackCandidates]){
+    const normalized=(val||"").trim();
+    if(!normalized) continue;
+    if(!looksLikeSKU(normalized)) continue;
+    if(seen.has(normalized)) continue;
+    seen.add(normalized);
+    ordered.push(normalized);
+  }
+  return { sku, skuCandidates: ordered };
 }
 function getFieldCandidates(field){
   const names=[field,`${field}_display`];
@@ -74,16 +85,27 @@ function getFieldCandidates(field){
 }
 function pickFieldValue(field){ const vals=getFieldCandidates(field); return vals.length?vals[0]:null; }
 function gatherBasePayload(){
-  const sku=findSKU();
+  const { sku, skuCandidates } = collectSkuDetection();
   const internalId=pickFieldValue("id");
   const bcProductId=pickFieldValue("custitem_tt_bc_product_id");
   const bcVariantId=pickFieldValue("custitem_tt_bc_variant_id");
   return {
     sku: sku||null,
+    skuCandidates,
+    detectedSkuCount: skuCandidates.length,
     internalId: internalId||null,
     bcProductId: bcProductId||null,
     bcVariantId: bcVariantId||null
   };
+}
+function arraysEqual(a,b){
+  const arrA=Array.isArray(a)?a:[];
+  const arrB=Array.isArray(b)?b:[];
+  if(arrA.length!==arrB.length) return false;
+  for(let i=0;i<arrA.length;i++){
+    if(arrA[i]!==arrB[i]) return false;
+  }
+  return true;
 }
 function baseEquals(a,b){
   if(!a&&!b) return true;
@@ -91,16 +113,27 @@ function baseEquals(a,b){
   return (a.sku||null)===(b.sku||null)
     && (a.internalId||null)===(b.internalId||null)
     && (a.bcProductId||null)===(b.bcProductId||null)
-    && (a.bcVariantId||null)===(b.bcVariantId||null);
+    && (a.bcVariantId||null)===(b.bcVariantId||null)
+    && (a.detectedSkuCount||0)===(b.detectedSkuCount||0)
+    && arraysEqual(a.skuCandidates,b.skuCandidates);
 }
 let lastDetectedPayload=null;
+function notifyDetection(payload){
+  try{
+    const message={type:"ns-detected", payload};
+    const sendPromise=chrome.runtime.sendMessage(message);
+    if(sendPromise&&typeof sendPromise.catch==="function") sendPromise.catch(()=>{});
+  }catch(e){
+    // ignore background errors
+  }
+}
 function updateDetectedPayload(){
   const base=gatherBasePayload();
-  const hasAny=!!(base.sku||base.internalId||base.bcProductId||base.bcVariantId);
+  const hasAny=!!(base.sku||base.internalId||base.bcProductId||base.bcVariantId||base.detectedSkuCount);
   if(!hasAny){
     if(lastDetectedPayload!==null){
       lastDetectedPayload=null;
-      chrome.runtime.sendMessage({type:"netsuite-detected", payload:null});
+      notifyDetection(null);
     }
     return;
   }
@@ -108,11 +141,13 @@ function updateDetectedPayload(){
     sku:lastDetectedPayload.sku||null,
     internalId:lastDetectedPayload.internalId||null,
     bcProductId:lastDetectedPayload.bcProductId||null,
-    bcVariantId:lastDetectedPayload.bcVariantId||null
+    bcVariantId:lastDetectedPayload.bcVariantId||null,
+    detectedSkuCount:lastDetectedPayload.detectedSkuCount||0,
+    skuCandidates:Array.isArray(lastDetectedPayload.skuCandidates)?lastDetectedPayload.skuCandidates.slice():[]
   }:null;
   if(!baseEquals(base,prevBase)){
     lastDetectedPayload={...base, detectedAt: Date.now()};
-    chrome.runtime.sendMessage({type:"netsuite-detected", payload:lastDetectedPayload});
+    notifyDetection(lastDetectedPayload);
   }
 }
 const obs=new MutationObserver(()=>updateDetectedPayload());

--- a/options-secure.js
+++ b/options-secure.js
@@ -2,6 +2,14 @@ import { encryptJSON } from "./crypto.js";
 
 function $(id){ return document.getElementById(id); }
 
+async function requestBadgeRefresh(){
+  try{
+    await chrome.runtime.sendMessage({ type: "refresh-badge" });
+  }catch(e){
+    // ignore background errors
+  }
+}
+
 async function saveEncrypted(){
   const pass = $('passphrase').value;
   const obj = {
@@ -23,11 +31,13 @@ $('unlock').addEventListener('click', async () => {
   if (!pass) { alert('Enter your password'); return; }
   const res = await chrome.runtime.sendMessage({ type: "unlock-creds", passphrase: pass });
   $('out').textContent = res?.ok ? 'Unlocked ✅' : (res?.error || 'Error');
+  await requestBadgeRefresh();
 });
 
 $('lock').addEventListener('click', async () => {
   const res = await chrome.runtime.sendMessage({ type: "lock-creds" });
   $('out').textContent = res?.ok ? 'Locked 🔒' : (res?.error || 'Error');
+  await requestBadgeRefresh();
 });
 
 $('testBtn').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add badge helpers in the background service worker to reflect lock status, detection counts, and refresh on tab events or explicit requests
- expand the content script payload to include SKU candidates and send the new `ns-detected` message for badge updates
- request badge refreshes from the popup and secure options views when detection data is used or credentials are locked/unlocked

## Testing
- not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68cdc2c919f883258e7bddc2b92f91f4