### PR TITLE
Add selectors for BC ID detection in NetSuite view mode

### DIFF
--- a/content.js
+++ b/content.js
@@ -65,6 +65,7 @@ function getFieldCandidates(field){
     selectors.add(`input[id$="${name}"]`);
     selectors.add(`[name="${name}"]`);
     selectors.add(`#${name}`);
+    selectors.add(`#${name}_val`);
     selectors.add(`[data-fieldid="${name}"] input`);
     selectors.add(`[data-fieldid="${name}"] span`);
     selectors.add(`[data-fieldid="${name}"] .uir-field-input`);
@@ -72,6 +73,14 @@ function getFieldCandidates(field){
     selectors.add(`span#${name}`);
     selectors.add(`span[name="${name}"]`);
     selectors.add(`span[id$="${name}"]`);
+    selectors.add(`span[id^="${name}_"][id$="_val"]`);
+    selectors.add(`span[id*="${name}"][id$="_val"]`);
+    selectors.add(`div[id^="${name}_"][id$="_val"]`);
+    selectors.add(`div[id*="${name}"][id$="_val"]`);
+    selectors.add(`[id^="${name}_"][id$="_val"]`);
+    selectors.add(`[id*="${name}"][id$="_val"]`);
+    selectors.add(`#${name}_val span`);
+    selectors.add(`#${name}_val div`);
   }
   const vals=new Set();
   selectors.forEach(sel=>{


### PR DESCRIPTION
## Summary
- extend field lookup selectors to cover NetSuite read-only nodes whose ids include the field name and end with `_val`
- include the corresponding `_val` containers and descendants so BC IDs are detected outside of edit mode while preserving deduplication

## Testing
- not run (manual verification required)

------
https://chatgpt.com/codex/tasks/task_e_68ce256199508325854e480b8d19d30f