### PR TITLE
Refactor popup to show consolidated ID summary

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -25,30 +25,18 @@
     .status.ok { color: #047857; }
     .status.bad { color: #dc2626; }
     .hidden { display: none !important; }
-    #netsuiteBody, #bcDetails { display: flex; flex-direction: column; gap: 8px; }
+    .summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+    .summary-column { display: flex; flex-direction: column; gap: 10px; padding: 12px; border-radius: 12px; background: #f8fafc; border: 1px solid #e2e8f0; }
+    .summary-column .column-header { display: flex; flex-direction: column; gap: 4px; }
+    .summary-column .column-title { font-weight: 600; font-size: 14px; color: #1f2937; }
+    .summary-column .column-meta { font-size: 12px; color: #6b7280; }
+    .summary-column .id-list { display: flex; flex-direction: column; gap: 8px; }
     .placeholder { padding: 14px; border-radius: 12px; background: #f1f5f9; border: 1px dashed #cbd5f5; font-size: 12px; text-align: center; }
-    .id-row { display: grid; grid-template-columns: auto 1fr auto; gap: 8px; align-items: center; padding: 8px 10px; border: 1px solid #e5e7eb; border-radius: 12px; background: #f9fafb; }
+    .id-row { display: grid; grid-template-columns: auto 1fr; gap: 8px; align-items: center; padding: 8px 10px; border: 1px solid #e5e7eb; border-radius: 12px; background: #ffffff; box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1); }
+    .id-row.has-action { grid-template-columns: auto 1fr auto; }
+    .id-row.highlight { border-color: #c7d2fe; background: #eef2ff; box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.15); }
     .id-label { font-size: 11px; font-weight: 700; color: #475569; text-transform: uppercase; letter-spacing: 0.05em; }
     .id-value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 4px 6px; border-radius: 6px; background: #ffffff; border: 1px solid #e5e7eb; min-height: 20px; display: flex; align-items: center; word-break: break-all; }
-    .comparison-section { margin-top: 4px; display: flex; flex-direction: column; gap: 10px; }
-    .comparison-list { display: flex; flex-direction: column; gap: 8px; }
-    .compare-row { border: 1px solid #e5e7eb; border-radius: 12px; padding: 10px 12px; transition: box-shadow 0.2s ease; }
-    .compare-top { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
-    .compare-label { font-weight: 600; font-size: 13px; color: #1f2937; }
-    .state-chip { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.06em; }
-    .compare-values { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin-top: 8px; }
-    .source-value { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: #475569; }
-    .source-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: #64748b; }
-    .source-value code { display: block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 4px 6px; border-radius: 6px; border: 1px solid rgba(148, 163, 184, 0.6); background: rgba(248, 250, 252, 0.8); color: #0f172a; word-break: break-all; }
-    .state-match { background: #f0fdf4; border-color: #bbf7d0; }
-    .state-match .state-chip { background: #bbf7d0; color: #166534; }
-    .state-missing { background: #fffbeb; border-color: #fde68a; }
-    .state-missing .state-chip { background: #fde68a; color: #92400e; }
-    .state-mismatch { background: #fef2f2; border-color: #fca5a5; }
-    .state-mismatch .state-chip { background: #fca5a5; color: #b91c1c; }
-    .banner { font-size: 12px; font-weight: 600; padding: 8px 10px; border-radius: 12px; border: 1px solid transparent; }
-    .banner.is-warning { background: #fef3c7; border-color: #fde68a; color: #b45309; }
-    .banner.is-error { background: #fee2e2; border-color: #fecaca; color: #b91c1c; }
     .toast { position: fixed; bottom: 12px; left: 50%; transform: translateX(-50%); background: #111827; color: #fff; padding: 6px 12px; border-radius: 999px; font-size: 12px; opacity: 0; transition: opacity .2s ease; box-shadow: 0 6px 18px rgba(15, 23, 42, 0.3); }
     .toast.show { opacity: 1; }
   </style>
@@ -73,30 +61,33 @@
     <div id="status" class="status muted"></div>
   </div>
 
-  <div class="card" id="netsuiteCard">
-    <div class="card-header" id="netsuiteHeader">
+  <div class="card" id="idSummaryCard">
+    <div class="card-header" id="summaryHeader">
       <div>
-        <div class="card-title">NetSuite IDs</div>
-        <div class="card-subtitle muted" id="netsuiteMeta">Waiting for detected data.</div>
-      </div>
-    </div>
-    <div class="card-body" id="netsuiteBody">
-      <div class="placeholder muted">No detected data.</div>
-    </div>
-  </div>
-
-  <div class="card hidden" id="bigcommerceCard">
-    <div class="card-header" id="bcHeader">
-      <div>
-        <div class="card-title">BigCommerce IDs</div>
-        <div class="card-subtitle muted" id="bcMeta">Look up an SKU to view IDs.</div>
+        <div class="card-title">ID Summary</div>
+        <div class="card-subtitle muted" id="summaryMeta">Review NetSuite detections alongside BigCommerce lookups.</div>
       </div>
     </div>
     <div class="card-body">
-      <div id="bcDetails"></div>
-      <div class="comparison-section hidden" id="comparisonSection">
-        <div id="comparisonBanner" class="banner hidden"></div>
-        <div id="comparisonResults" class="comparison-list"></div>
+      <div class="summary-grid">
+        <div class="summary-column" id="netsuiteColumn">
+          <div class="column-header">
+            <div class="column-title">NetSuite</div>
+            <div class="column-meta" id="netsuiteMeta">Waiting for detected data.</div>
+          </div>
+          <div class="id-list" id="netsuiteSummary">
+            <div class="placeholder muted">No detected data.</div>
+          </div>
+        </div>
+        <div class="summary-column" id="bcColumn">
+          <div class="column-header">
+            <div class="column-title">BigCommerce</div>
+            <div class="column-meta" id="bcMeta">Look up an SKU to view IDs.</div>
+          </div>
+          <div class="id-list" id="bcSummary">
+            <div class="placeholder muted">No lookup data yet.</div>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace the separate NetSuite/BigCommerce cards with a single consolidated ID summary layout
- highlight BigCommerce product and variant IDs as copyable entries
- simplify popup rendering logic to feed the unified card and remove comparison UI

## Testing
- Manual verification of popup.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68ce261f1d888325b6fa8ab045590bf9