### PR TITLE
Expand field detection for BC ID read-only containers

### DIFF
--- a/content.js
+++ b/content.js
@@ -81,6 +81,23 @@ function getFieldCandidates(field){
     selectors.add(`[id*="${name}"][id$="_val"]`);
     selectors.add(`#${name}_val span`);
     selectors.add(`#${name}_val div`);
+    const fsBases=[
+      `#${name}_fs`,
+      `[id^="${name}_"][id$="_fs"]`,
+      `[id*="${name}"][id$="_fs"]`,
+      `div[id^="${name}_"][id$="_fs"]`,
+      `div[id*="${name}"][id$="_fs"]`,
+      `span[id^="${name}_"][id$="_fs"]`,
+      `span[id*="${name}"][id$="_fs"]`,
+      `td[id^="${name}_"][id$="_fs"]`,
+      `td[id*="${name}"][id$="_fs"]`
+    ];
+    const fsDescendants=[""," .uir-field"," .inputreadonly"," .value"," a"];
+    for(const baseSel of fsBases){
+      for(const suffix of fsDescendants){
+        selectors.add(`${baseSel}${suffix}`);
+      }
+    }
   }
   const vals=new Set();
   selectors.forEach(sel=>{


### PR DESCRIPTION
## Summary
- expand field candidate selectors to cover `_fs` containers and their descendant text holders so BigCommerce IDs are detected when rendered read-only

## Testing
- not run (manual browser verification required)

------
https://chatgpt.com/codex/tasks/task_e_68ce29cfcbf08325ac3e1bc2cc280fe8