### PR TITLE
Expand NetSuite read-only selectors for field detection

### DIFF
--- a/content.js
+++ b/content.js
@@ -92,7 +92,18 @@ function getFieldCandidates(field){
       `td[id^="${name}_"][id$="_fs"]`,
       `td[id*="${name}"][id$="_fs"]`
     ];
-    const fsDescendants=[""," .uir-field"," .inputreadonly"," .value"," a"];
+    const fsDescendants=[
+      "",
+      " .uir-field",
+      " .inputreadonly",
+      " .value",
+      " .value *",
+      " a",
+      " .uir-field-value",
+      " .uir-field-value *",
+      " .uir-field-wrapper",
+      " .uir-field-wrapper *"
+    ];
     for(const baseSel of fsBases){
       for(const suffix of fsDescendants){
         selectors.add(`${baseSel}${suffix}`);


### PR DESCRIPTION
## Summary
- extend the field selector suffix list within `getFieldCandidates`
- cover read-only NetSuite wrappers such as `.uir-field-value` and `.uir-field-wrapper`
- ensure descendant elements within those wrappers are also searched for captured values

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68ce2e8324748325ad4270660b1b103d