### PR TITLE
Highlight NetSuite IDs against BC lookup results

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -35,6 +35,12 @@
     .id-row { display: grid; grid-template-columns: auto 1fr; gap: 8px; align-items: center; padding: 8px 10px; border: 1px solid #e5e7eb; border-radius: 12px; background: #ffffff; box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1); }
     .id-row.has-action { grid-template-columns: auto 1fr auto; }
     .id-row.highlight { border-color: #c7d2fe; background: #eef2ff; box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.15); }
+    .id-row.match { border-color: #bbf7d0; background: #f0fdf4; box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.15); }
+    .id-row.match .id-label { color: #047857; }
+    .id-row.match .id-value { border-color: #86efac; background: #dcfce7; color: #065f46; }
+    .id-row.mismatch { border-color: #fecaca; background: #fef2f2; box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.2); }
+    .id-row.mismatch .id-label { color: #b91c1c; }
+    .id-row.mismatch .id-value { border-color: #fda4af; background: #fee2e2; color: #991b1b; }
     .id-label { font-size: 11px; font-weight: 700; color: #475569; text-transform: uppercase; letter-spacing: 0.05em; }
     .id-value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; padding: 4px 6px; border-radius: 6px; background: #ffffff; border: 1px solid #e5e7eb; min-height: 20px; display: flex; align-items: center; word-break: break-all; }
     .toast { position: fixed; bottom: 12px; left: 50%; transform: translateX(-50%); background: #111827; color: #fff; padding: 6px 12px; border-radius: 999px; font-size: 12px; opacity: 0; transition: opacity .2s ease; box-shadow: 0 6px 18px rgba(15, 23, 42, 0.3); }


### PR DESCRIPTION
## Summary
- track the most recent BigCommerce lookup in the popup and compare NetSuite BC product/variant IDs against it to surface match or mismatch states
- ensure lookup handlers pass their results into the renderer so the comparison refreshes after direct or background lookups
- style the new match and mismatch row states to visually distinguish aligned NetSuite data from discrepancies

## Testing
- Tests not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce35949dec8325ae1024696dbe16bb