### PR TITLE
Add BigCommerce comparison column to popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -25,7 +25,8 @@
     .status.ok { color: #047857; }
     .status.bad { color: #dc2626; }
     .hidden { display: none !important; }
-    .summary-grid { display: flex; flex-direction: column; gap: 12px; }
+    .summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; align-items: start; }
+    .summary-grid:not(.has-bc) #bigcommerceColumn { display: none; }
     .summary-column { display: flex; flex-direction: column; gap: 10px; padding: 12px; border-radius: 12px; background: #f8fafc; border: 1px solid #e2e8f0; }
     .summary-column .column-header { display: flex; flex-direction: column; gap: 4px; }
     .summary-column .column-title { font-weight: 600; font-size: 14px; color: #1f2937; }
@@ -75,7 +76,7 @@
       </div>
     </div>
     <div class="card-body">
-      <div class="summary-grid">
+      <div class="summary-grid" id="summaryGrid">
         <div class="summary-column" id="netsuiteColumn">
           <div class="column-header">
             <div class="column-title">NetSuite</div>
@@ -83,6 +84,15 @@
           </div>
           <div class="id-list" id="netsuiteSummary">
             <div class="placeholder muted">No detected data.</div>
+          </div>
+        </div>
+        <div class="summary-column" id="bigcommerceColumn">
+          <div class="column-header">
+            <div class="column-title">BigCommerce</div>
+            <div class="column-meta" id="bigcommerceMeta">Run a lookup to compare.</div>
+          </div>
+          <div class="id-list" id="bigcommerceSummary">
+            <div class="placeholder muted">Run a lookup to compare.</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- convert the summary grid to a responsive layout and add a BigCommerce column with metadata
- hide the BigCommerce column when no lookup is available or when all values match
- render mismatched BigCommerce values with copy controls and preserve NetSuite highlighting

## Testing
- not run (extension UI change)


------
https://chatgpt.com/codex/tasks/task_e_68ce39d5a590832587451604796ce56e