### PR TITLE
Reset BigCommerce results when NetSuite payload changes

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -82,6 +82,17 @@ function normalizeValue(value) {
   return String(value);
 }
 
+const NETSUITE_PAYLOAD_KEYS = ['sku', 'internalId', 'bcProductId', 'bcVariantId'];
+
+function getComparablePayloadValue(payload, key) {
+  if (!payload || typeof payload !== 'object') return '';
+  return normalizeValue(payload[key]);
+}
+
+function payloadsAreEqual(a, b) {
+  return NETSUITE_PAYLOAD_KEYS.every((key) => getComparablePayloadValue(a, key) === getComparablePayloadValue(b, key));
+}
+
 function renderIdRow(label, id, value, options = {}) {
   const { copy = false, highlight = false, matchState = null } = options;
   const normalized = normalizeValue(value);
@@ -278,7 +289,12 @@ function applyLookupStatusFromSummary(summary) {
 
 
 function renderNetSuite(payload){
-  latestNetSuitePayload = payload || null;
+  const nextPayload = payload || null;
+  const payloadChanged = !payloadsAreEqual(latestNetSuitePayload, nextPayload);
+  latestNetSuitePayload = nextPayload;
+  if (payloadChanged && lastSearchResult) {
+    lastSearchResult = null;
+  }
   renderIdSummary();
 }
 


### PR DESCRIPTION
## Summary
- add a comparison helper to detect when the detected NetSuite payload has changed
- clear cached BigCommerce lookup results when the payload changes so the summary resets

## Testing
- not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68cecc1974a48325bee27c9d8d4878e0