### PR TITLE
Add localhost host permission for cookie access

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
     "https://api.bigcommerce.com/*",
     "https://api-b2b.bigcommerce.com/*",
     "https://*.netsuite.com/*",
-    "https://bc-sku-lookup.local/*"
+    "https://bc-sku-lookup.local/*",
+    "https://localhost/*"
   ],
   "background": {
     "service_worker": "background.js",


### PR DESCRIPTION
### Motivation
- Resolve host-permission errors for `chrome.cookies` calls that use `url: "https://localhost/"` by granting the extension explicit localhost access.

### Description
- Add `https://localhost/*` to `host_permissions` in `manifest.json` while leaving the existing `https://bc-sku-lookup.local/*` entry intact.

### Testing
- Confirmed `manifest.json` is valid JSON using `node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8'))"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd26fada948325b1cb25fec15d6dd2)