### PR TITLE
Add UI to clear stored account cookies; defensively handle corrupted and legacy cookies

### DIFF
--- a/account-store.js
+++ b/account-store.js
@@ -28,8 +28,16 @@ async function readAccountsCookie() {
     if (!cookie || !cookie.value) {
       return [];
     }
-    const decoded = decodeURIComponent(cookie.value);
-    const parsed = JSON.parse(decoded);
+    let parsed;
+    try {
+      const decoded = decodeURIComponent(cookie.value);
+      parsed = JSON.parse(decoded);
+    } catch (parseError) {
+      console.warn('Accounts cookie is invalid. Clearing it to recover.', parseError);
+      await chrome.cookies.remove({ url: COOKIE_URL, name: COOKIE_NAME }).catch(() => null);
+      await Promise.all(LEGACY_COOKIE_URLS.map((url) => chrome.cookies.remove({ url, name: COOKIE_NAME }).catch(() => null)));
+      return [];
+    }
     if (!Array.isArray(parsed)) {
       return [];
     }
@@ -199,6 +207,7 @@ export function formatAccountLabel(account) {
 
 export async function clearAccounts() {
   await chrome.cookies.remove({ url: COOKIE_URL, name: COOKIE_NAME });
+  await Promise.all(LEGACY_COOKIE_URLS.map((url) => chrome.cookies.remove({ url, name: COOKIE_NAME }).catch(() => null)));
   await setActiveAccountId(null);
 }
 

--- a/background.js
+++ b/background.js
@@ -6,6 +6,7 @@ import {
   listAccounts,
   listAccountSummaries,
   mergeAccounts,
+  clearAccounts,
   replaceAccounts,
   removeAccount,
   setActiveAccountId,
@@ -1036,6 +1037,10 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           getActiveAccountId(),
         ]);
         sendResponse({ ok: removed, accounts, activeAccountId });
+      } else if (msg?.type === "account:clear-all") {
+        await clearAccounts();
+        await refreshAllBadges();
+        sendResponse({ ok: true, accounts: [], activeAccountId: null });
       } else if (msg?.type === "account:set-active") {
         await setActiveAccountId(msg?.id || null);
         await refreshAllBadges();

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
     "https://api.bigcommerce.com/*",
     "https://api-b2b.bigcommerce.com/*",
     "https://*.netsuite.com/*",
-    "https://bc-sku-lookup.local/*"
+    "https://bc-sku-lookup.local/*",
+    "https://localhost/*"
   ],
   "background": {
     "service_worker": "background.js",

--- a/options-secure.js
+++ b/options-secure.js
@@ -360,6 +360,25 @@ async function handleImportFileSelection(event) {
   }
 }
 
+async function clearAccountCookies() {
+  const confirmed = confirm('This will remove all saved BigCommerce accounts from this browser. Continue?');
+  if (!confirmed) return;
+  try {
+    const response = await chrome.runtime.sendMessage({ type: 'account:clear-all' });
+    if (!response?.ok) {
+      throw new Error(response?.error || 'Could not clear account cookies.');
+    }
+    accountSummaries = [];
+    activeAccountId = null;
+    renderAccountList();
+    resetForm();
+    setBackupStatus('Account cookies cleared. You can now create the account again.', 'ok');
+    setFormStatus('All account cookies were cleared.', 'ok');
+  } catch (error) {
+    setBackupStatus(String(error), 'error');
+  }
+}
+
 function init() {
   $('accountForm').addEventListener('submit', saveAccount);
   $('resetForm').addEventListener('click', () => {
@@ -369,6 +388,7 @@ function init() {
   $('exportAccounts')?.addEventListener('click', exportAccountsBackup);
   $('importAccounts')?.addEventListener('click', openImportPicker);
   $('importFile')?.addEventListener('change', handleImportFileSelection);
+  $('clearAccountCookies')?.addEventListener('click', clearAccountCookies);
   updateFormTitle();
   loadAccounts();
 }

--- a/options.html
+++ b/options.html
@@ -106,6 +106,9 @@
         <button type="button" class="secondary" id="importAccounts">Import accounts</button>
         <input type="file" id="importFile" accept="application/json,.json" hidden />
       </div>
+      <div class="inline-actions">
+        <button type="button" class="danger" id="clearAccountCookies">Clear account cookies</button>
+      </div>
       <p class="hint">If you export without password, the JSON remains readable. With password, the file content is encrypted and requires the same password to import.</p>
       <div class="status" id="backupStatus"></div>
     </section>


### PR DESCRIPTION
### Motivation
- Provide a user-accessible way to remove all saved BigCommerce accounts and ensure the extension can recover from invalid or legacy cookie formats/locations.

### Description
- Add defensive parsing in `readAccountsCookie` to catch invalid JSON, log a warning, and remove the current cookie plus any `LEGACY_COOKIE_URLS` entries before returning an empty list.
- Ensure `clearAccounts` also removes cookies from legacy URLs and clears the active account id.
- Expose a new `account:clear-all` message in `background.js` which calls `clearAccounts`, refreshes badges, and returns an empty account list and null active id.
- Add a "Clear account cookies" button to `options.html` and implement `clearAccountCookies` in `options-secure.js` that prompts the user, sends the `account:clear-all` message, and updates the UI on success or error.
- Add `https://localhost/*` to `host_permissions` in `manifest.json`.

### Testing
- No automated tests were added or modified for this change.
- No automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd26fada948325b1cb25fec15d6dd2)